### PR TITLE
RPCh integration

### DIFF
--- a/common.pas
+++ b/common.pas
@@ -76,7 +76,9 @@ uses
 {$ENDIF POSIX}
   // web3
   web3.eth.alchemy,
-  web3.eth.erc20;
+  web3.eth.erc20,
+  // project
+  docker;
 
 {$I alchemy.api.key}
 {$I etherscan.api.key}
@@ -149,6 +151,9 @@ begin
     Result := web3.eth.alchemy.endpoint(web3.Optimism, ALCHEMY_API_KEY_OPTIMISM, core)
   else
     Result := TResult<string>.Err('', System.SysUtils.Format('invalid port: %d', [port]));
+  if Result.isOk then
+    if docker.getContainerId(RPCh_CONTAINER_NAME) <> '' then
+      Result := TResult<string>.Ok('http://localhost:8080/?exit-provider=' + Result.Value);
 end;
 
 constructor TSemVer.Create(const aMajor, aMinor, aPatch: Integer);

--- a/docker.mac.pas
+++ b/docker.mac.pas
@@ -5,6 +5,12 @@ interface
 function supported: Boolean;
 function installed: Boolean;
 function installer: string;
+function running: Boolean;
+function start: Boolean;
+function pull(const image: string): Boolean;
+function run(const name, command: string): Boolean;
+function getContainerId(const name: string): string;
+function stop(const containerId: string): Boolean;
 
 implementation
 
@@ -25,6 +31,36 @@ begin
 {$ELSE}
   Result := 'https://desktop.docker.com/mac/main/amd64/Docker.dmg';
 {$ENDIF}
+end;
+
+function running: Boolean;
+begin
+  Result := False;
+end;
+
+function start: Boolean;
+begin
+  Result := False;
+end;
+
+function pull(const image: string): Boolean;
+begin
+  Result := False;
+end;
+
+function run(const name, command: string): Boolean;
+begin
+  Result := False;
+end;
+
+function getContainerId(const name: string): string;
+begin
+  Result := '';
+end;
+
+function stop(const containerId: string): Boolean;
+begin
+  Result := True;
 end;
 
 end.

--- a/docker.pas
+++ b/docker.pas
@@ -33,8 +33,18 @@ type
 var
   callback: TFunc<TFrmDocker>;
 
-function supported: Boolean;
-function installed: Boolean;
+function supported: Boolean; // returns true if Docker Engine can run, otherwise false
+function installed: Boolean; // returns true if Docker Engine is installed, otherwise false
+function running: Boolean;   // retruns true if Docker Engine is running, otherwise false
+function start: Boolean;
+function pull(const image: string): Boolean;
+function run(const containerName, command: string): Boolean;
+function getContainerId(const name: string): string;
+function stop(const containerId: string): Boolean;
+
+const
+  RPCh_DOCKER_IMAGE   = 'europe-west6-docker.pkg.dev/rpch-375921/rpch/rpc-server:6b9862f';
+  RPCh_CONTAINER_NAME = 'rpc-server';
 
 implementation
 
@@ -87,6 +97,66 @@ begin
 {$ENDIF MACOS}
 {$IFDEF MSWINDOWS}
   Result := docker.win.installer;
+{$ENDIF MSWINDOWS}
+end;
+
+function running: Boolean;
+begin
+{$IFDEF MACOS}
+  Result := docker.mac.running;
+{$ENDIF MACOS}
+{$IFDEF MSWINDOWS}
+  Result := docker.win.running;
+{$ENDIF MSWINDOWS}
+end;
+
+function start: Boolean;
+begin
+{$IFDEF MACOS}
+  Result := docker.mac.start;
+{$ENDIF MACOS}
+{$IFDEF MSWINDOWS}
+  Result := docker.win.start;
+{$ENDIF MSWINDOWS}
+end;
+
+function pull(const image: string): Boolean;
+begin
+{$IFDEF MACOS}
+  Result := docker.mac.pull(image);
+{$ENDIF MACOS}
+{$IFDEF MSWINDOWS}
+  Result := docker.win.pull(image);
+{$ENDIF MSWINDOWS}
+end;
+
+function run(const containerName, command: string): Boolean;
+begin
+{$IFDEF MACOS}
+  Result := docker.mac.run(containerName, command);
+{$ENDIF MACOS}
+{$IFDEF MSWINDOWS}
+  Result := docker.win.run(containerName, command);
+{$ENDIF MSWINDOWS}
+end;
+
+function getContainerId(const name: string): string;
+begin
+{$IFDEF MACOS}
+  Result := docker.mac.getContainerId(name);
+{$ENDIF MACOS}
+{$IFDEF MSWINDOWS}
+  Result := docker.win.getContainerId(name);
+{$ENDIF MSWINDOWS}
+end;
+
+function stop(const containerId: string): Boolean;
+begin
+{$IFDEF MACOS}
+  Result := docker.mac.stop(containerId);
+{$ENDIF MACOS}
+{$IFDEF MSWINDOWS}
+  Result := docker.win.stop(containerId);
 {$ENDIF MSWINDOWS}
 end;
 

--- a/docker.win.pas
+++ b/docker.win.pas
@@ -178,7 +178,7 @@ function start: Boolean;
   end;
 
 begin
-  Result := ShellExecute(0, 'open', PChar(desktop), nil, nil, SW_HIDE) > 32;
+  Result := ShellExecute(0, 'open', PChar(desktop), nil, nil, SW_SHOW) > 32;
 end;
 
 function pull(const image: string): Boolean;

--- a/thread.pas
+++ b/thread.pas
@@ -6,9 +6,20 @@ uses
   // Delphi
   System.Classes;
 
+procedure lock(const O: TObject; const P: TThreadProcedure);
 procedure synchronize(const P: TThreadProcedure);
 
 implementation
+
+procedure lock(const O: TObject; const P: TThreadProcedure);
+begin
+  TMonitor.Enter(O);
+  try
+    P
+  finally
+    TMonitor.Exit(O);
+  end;
+end;
 
 procedure synchronize(const P: TThreadProcedure);
 begin


### PR DESCRIPTION
When a transaction comes in *and* Docker Desktop is installed, Militereum will...
1. Start Docker Engine if it isn’t running, and
2. Pull the RPCh image if a RPCh container isn’t running already, and
3. Run the RPCh image if a RPCh container isn’t running already.

When the RPCh container is running and Militereum decides to forward (not block) a transaction, it is forwarded to `http://localhost:8080/?exit-provider=XXX` where `XXX` is an [Alchemy](https://www.alchemy.com/) endpoint with our Alchemy API key.

When Militereum is terminated and the RPCh container is running, Militereum will stop the container.

Please note we have implemented Windows only at this point. The macOS implementation will need to come later.

Please [refer to this earlier commit](https://github.com/svanas/Militereum/commit/c6c87d03ae2280d88ffa85258be9161fde9c8dd2) if you want to know where and when we are downloading and installing Docker Desktop.